### PR TITLE
Add info labels to the ElasTest docker images.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,9 @@ node('docker'){
         stage "Build image - Package"
             echo ("Building docker image...")
             sh 'cp build/libs/elastest-platform-manager-*.jar docker/elastest-platform-manager/epm.jar'
-            def myimage = docker.build("elastest/epm:latest","./docker/elastest-platform-manager")
+            //def myimage = docker.build("elastest/epm:latest","./docker/elastest-platform-manager")
+            sh 'cd docker/elastest-platform-manager; docker build --build-arg GIT_COMMIT=$(git rev-parse HEAD) --build-arg COMMIT_DATE=$(git log -1 --format=%cd --date=format:%Y-%m-%dT%H:%M:%S) . -t elastest/epm:latest'
+            def myimage = docker.image('elastest/epm:latest')
 
         stage "Run image"
             echo "Run the image..."

--- a/docker/elastest-platform-manager/Dockerfile
+++ b/docker/elastest-platform-manager/Dockerfile
@@ -1,6 +1,16 @@
 FROM openjdk:alpine
 MAINTAINER baeldung.com
 
+# Set Image Labels
+ARG GIT_COMMIT=unspecified
+LABEL git_commit=$GIT_COMMIT
+
+ARG COMMIT_DATE=unspecified
+LABEL commit_date=$COMMIT_DATE
+
+ARG VERSION=unspecified
+LABEL version=$VERSION 
+
 COPY epm.jar .
 
 EXPOSE 8180


### PR DESCRIPTION
These labels provide the version info about ElasTest and its componentes for the users and developers

- Label for the commit id
- Label for the commit date
- Label for component version